### PR TITLE
refactor to support prefering left most chal type in response challenges

### DIFF
--- a/sewer/client.py
+++ b/sewer/client.py
@@ -474,7 +474,7 @@ class Client:
         )
         self.logger.info(
             "get_identifier_authorization got %s, token=%s"
-            % (challenge_url, challenge_token)
+            % (identifier_auth["challenge_url"], identifier_auth["token"])
         )
         return identifier_auth
 

--- a/sewer/client.py
+++ b/sewer/client.py
@@ -398,7 +398,9 @@ class Client:
         self.logger.info("apply_for_cert_issuance_success")
         return authorizations, finalize_url
 
-    def get_identifier_auth_challenge(self, response_challenges):
+    def get_identifier_auth_challenge(
+        self, domain, auth_url, wildcard, response_challenges
+    ):
         allowed_challenge_types = [c["type"] for c in response_challenges]
 
         # left most chal_type wins
@@ -455,7 +457,7 @@ class Client:
         domain = response_json["identifier"]["value"]
         wildcard = response_json.get("wildcard")
         identifier_auth = self.get_identifier_auth_challenge(
-            response_json["challenges"]
+            domain, auth_url, wildcard, response_json["challenges"]
         )
 
         if not identifier_auth:


### PR DESCRIPTION
also apparently  re-format some code 

this would allow providers that implement both dns and https auth, then have sewer prefer one over the other when actually completing the auth step